### PR TITLE
resolve: show keyboard list if no device connection #50

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-redux": "^7.2.2",
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
+    "redux-devtools-extension": "^2.13.8",
     "redux-thunk": "^2.3.0",
     "typescript": "^4.1.3",
     "web-vitals": "^0.2.4"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './App.css';
 import { BrowserRouter, Switch, Route } from 'react-router-dom';
 
-import Configure from './components/configure/Configure';
+import Configure from './components/configure/Configure.container';
 import Hid from './services/hid/ui/Hid';
 import Top from './Top';
 

--- a/src/actions/actions.ts
+++ b/src/actions/actions.ts
@@ -4,7 +4,7 @@ import {
 } from '../components/configure/keycodes/Keycodes.container';
 
 export type Device = {
-  name: string;
+  productName: string;
   vendorId: number;
   productId: number;
 };

--- a/src/actions/hid.action.ts
+++ b/src/actions/hid.action.ts
@@ -4,12 +4,12 @@ import { RootState } from '../store/state';
 import { Device } from './actions';
 
 export const HID_ACTIONS = '@Hid';
-export const HID_CONNECT_DEVICE = `${HID_ACTIONS}/ConnectDevice`;
+export const HID_OPEN_DEVICE = `${HID_ACTIONS}/OpenDevice`;
 export const HID_UPDATE_DEVICE_LIST = `${HID_ACTIONS}/UpdateDeviceList`;
 const hidActions = {
   connectDevice: (id: number) => {
     return {
-      type: HID_CONNECT_DEVICE,
+      type: HID_OPEN_DEVICE,
       value: { id: id },
     };
   },
@@ -42,7 +42,6 @@ export const hidActionsThunk = {
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
   ) => {
-    console.log(`connectDevice(${targetDeviceId})`);
     dispatch(hidActions.connectDevice(targetDeviceId));
     //TODO: close current connected keyboard if exist
     //TODO: open the connected keyboard
@@ -52,7 +51,6 @@ export const hidActionsThunk = {
     dispatch: ThunkDispatch<RootState, undefined, ActionTypes>,
     getState: () => RootState
   ) => {
-    console.log(`connectAnotherDevice`);
     const { hid } = getState();
     const result = await hid.instance.connect();
     console.log(result);
@@ -68,11 +66,7 @@ const getAuthorizedDevices = async (hid: IHid): Promise<Device[]> => {
 
   const devices: Device[] = keyboards.map((kbd) => {
     const info: IDeviceInformation = kbd.getInformation();
-    const device: Device = {
-      name: info.productName,
-      vendorId: Number(info.vendorId),
-      productId: Number(info.productId),
-    };
+    const device: Device = info;
     return device;
   });
   return devices;

--- a/src/components/configure/Configure.container.ts
+++ b/src/components/configure/Configure.container.ts
@@ -1,0 +1,20 @@
+import { connect } from 'react-redux';
+import Configure from './Configure';
+import { RootState } from '../../store/state';
+import { hidActionsThunk } from '../../actions/hid.action';
+
+export type ConfigureStateType = {};
+const mapStateToProps = (state: RootState): ConfigureStateType => {
+  return {};
+};
+
+const mapDispatchToProps = (_dispatch: any) => {
+  return {
+    updateAuthorizedDeviceList: () =>
+      _dispatch(hidActionsThunk.updateAuthorizedDeviceList()),
+  };
+};
+
+export type ConfigureActionsType = ReturnType<typeof mapDispatchToProps>;
+
+export default connect(mapStateToProps, mapDispatchToProps)(Configure);

--- a/src/components/configure/Configure.tsx
+++ b/src/components/configure/Configure.tsx
@@ -1,10 +1,24 @@
 import React from 'react';
 import './Configure.scss';
 import Header from './header/Header.container';
-import Content from './content/Content';
+import Content from './content/Content.container';
 import CssBaseline from '@material-ui/core/CssBaseline';
+import {
+  ConfigureActionsType,
+  ConfigureStateType,
+} from './Configure.container';
 
-export default class Configure extends React.Component {
+type OwnProps = {};
+type ConfigureProps = OwnProps &
+  Partial<ConfigureStateType> &
+  Partial<ConfigureActionsType>;
+export default class Configure extends React.Component<ConfigureProps, {}> {
+  constructor(props: ConfigureProps) {
+    super(props);
+  }
+  componentDidMount() {
+    this.props.updateAuthorizedDeviceList!();
+  }
   render() {
     return (
       <React.Fragment>

--- a/src/components/configure/content/Content.container.ts
+++ b/src/components/configure/content/Content.container.ts
@@ -1,0 +1,21 @@
+import { connect } from 'react-redux';
+import Content from './Content';
+import { RootState } from '../../../store/state';
+import { Device } from '../../../actions/actions';
+
+export type ContentStateType = {
+  openedDeviceId: number;
+  devices: { [id: number]: Device };
+};
+const mapStateToProps = (state: RootState): ContentStateType => {
+  return {
+    openedDeviceId: state.hid.openedDeviceId,
+    devices: state.hid.devices,
+  };
+};
+
+const mapDispatchToProps = {};
+
+export type ContentActionsType = typeof mapDispatchToProps;
+
+export default connect(mapStateToProps, mapDispatchToProps)(Content);

--- a/src/components/configure/content/Content.scss
+++ b/src/components/configure/content/Content.scss
@@ -19,25 +19,19 @@
     flex-direction: column;
     padding-bottom: 32px;
     background-color: white;
-    .keydiff-wrapper {
-      display: flex;
-      flex-direction: row;
-      justify-content: center;
-      margin-top: -32px;
-    }
-
-    .keyboards-wrapper {
-      display: flex;
-      flex-direction: row;
-
-      .balancer {
-        width: 140px;
-      }
-    }
+    min-height: 400px;
   }
   .keycode {
     display: flex;
     flex-direction: column;
     padding: $space-l;
+    .disable {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      background: rgba(255, 255, 255, 0.8);
+      margin-left: -16px;
+      margin-top: -16px;
+    }
   }
 }

--- a/src/components/configure/content/Content.tsx
+++ b/src/components/configure/content/Content.tsx
@@ -2,38 +2,31 @@ import React from 'react';
 import './Content.scss';
 import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
-//import kbdConfig from '../../../assets/files/lunakey-mini.json';
-import kbdConfig from '../../../assets/files/lunakey-mini-test.json';
-//import kbdConfig from '../../../assets/files/iso60.json';
-import Keydiff from '../keydiff/Keydiff';
 import Keycodes from '../keycodes/Keycodes.container';
-import Keyboards from '../keyboards/Keyboards';
-import KeyModel from '../../../models/KeyModel';
+import Keymap from '../keymap/Keymap';
+import { ContentActionsType, ContentStateType } from './Content.container';
+import { Device } from '../../../actions/actions';
+import NoKeyboard from '../nokeyboard/NoKeyboard';
+import KeyboardList from '../keyboardlist/KeyboardList.container';
 
-interface IContentState {
+type ContentState = {
   selectedLayer: number;
-}
+};
 
-export default class Content extends React.Component<{}, IContentState> {
-  private origKey = new KeyModel(
-    'Enter',
-    0,
-    0,
-    1.25,
-    2,
-    '#cccccc',
-    30,
-    2,
-    3,
-    -0.25,
-    0,
-    1.5,
-    1
-  );
-  private destKey = new KeyModel('Caps Lock', 0, 0, 2, 1, '#cccccc', -15, 3, 4);
-  constructor(props: {} | Readonly<{}>) {
+type OwnProps = {};
+
+type ContentProps = OwnProps &
+  Partial<ContentActionsType> &
+  Partial<ContentStateType>;
+
+export default class Content extends React.Component<
+  ContentProps,
+  ContentState
+> {
+  constructor(props: ContentProps | Readonly<ContentProps>) {
     super(props);
     this.state = {
+      //TODO: redux
       selectedLayer: 1,
     };
   }
@@ -49,35 +42,53 @@ export default class Content extends React.Component<{}, IContentState> {
   render() {
     return (
       <div className="content">
-        <div className="controller">
-          <div className="switch">
-            <Select
-              id="keyboard-layout-switch"
-              value={'Choc'}
-              onChange={() => {}}
-            >
-              <MenuItem value="MX">MX</MenuItem>
-              <MenuItem value="Choc">Choc</MenuItem>
-            </Select>
+        {Number.isNaN(this.props.openedDeviceId) ? (
+          ''
+        ) : (
+          <div className="controller">
+            <div className="switch">
+              <Select
+                id="keyboard-layout-switch"
+                value={'Choc'}
+                onChange={() => {}}
+              >
+                <MenuItem value="MX">MX</MenuItem>
+                <MenuItem value="Choc">Choc</MenuItem>
+              </Select>
+            </div>
           </div>
-        </div>
+        )}
         <div className="keymap">
-          <div className="keydiff-wrapper">
-            <div className="spacer"></div>
-            <Keydiff origin={this.origKey} destination={this.destKey} />
-            <div className="spacer"></div>
-          </div>
-          <div className="keyboards-wrapper">
-            <div className="spacer"></div>
-            <Keyboards config={kbdConfig} />
-            <div className="balancer"></div>
-            <div className="spacer"></div>
-          </div>
+          <ConnectedKeyboard
+            openedDeviceId={this.props.openedDeviceId!}
+            devices={this.props.devices || {}}
+          />
         </div>
         <div className="keycode">
           <Keycodes />
+          {Number.isNaN(this.props.openedDeviceId) ? (
+            <div className="disable"></div>
+          ) : (
+            ''
+          )}
         </div>
       </div>
     );
+  }
+}
+
+type ConnectedKeyboardProps = {
+  openedDeviceId: number;
+  devices: { [id: number]: Device };
+};
+function ConnectedKeyboard(props: ConnectedKeyboardProps) {
+  if (Number.isNaN(props.openedDeviceId)) {
+    if (0 < Object.entries(props.devices).length) {
+      return <KeyboardList />;
+    } else {
+      return <NoKeyboard />;
+    }
+  } else {
+    return <Keymap />;
   }
 }

--- a/src/components/configure/header/Header.container.ts
+++ b/src/components/configure/header/Header.container.ts
@@ -5,20 +5,18 @@ import { Device } from '../../../actions/actions';
 import { hidActionsThunk } from '../../../actions/hid.action';
 
 export type HeaderStateType = {
-  connected: boolean;
-  connectedDeviceId: number;
-  keyboardName: string;
+  openedDeviceId: number;
+  productName: string;
   vendorId: number;
   productId: number;
   devices: { [id: number]: Device };
 };
 const mapStateToProps = (state: RootState): HeaderStateType => {
-  const deviceId: number = state.hid.connectedDeviceId;
+  const deviceId: number = state.hid.openedDeviceId;
   const device: Device = state.hid.devices[deviceId];
   return {
-    connected: 0 <= deviceId,
-    connectedDeviceId: state.hid.connectedDeviceId,
-    keyboardName: device?.name || '',
+    openedDeviceId: state.hid.openedDeviceId,
+    productName: device?.productName || '',
     vendorId: device?.vendorId || NaN,
     productId: device?.productId || NaN,
     devices: state.hid.devices,
@@ -29,7 +27,6 @@ const mapDispatchToProps = (_dispatch: any) => {
   return {
     onClickDeviceMenuItem: (id: number) =>
       _dispatch(hidActionsThunk.connectDevice(id)),
-
     onClickAnotherDevice: () =>
       _dispatch(hidActionsThunk.connectAnotherDevice()),
     onClickDeviceMenu: () =>

--- a/src/components/configure/header/Header.scss
+++ b/src/components/configure/header/Header.scss
@@ -56,6 +56,10 @@
       min-width: 80px !important;
     }
   }
+
+  .hidden {
+    visibility: hidden;
+  }
 }
 
 .connected-device {

--- a/src/components/configure/header/Header.tsx
+++ b/src/components/configure/header/Header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './Header.scss';
 import logo from '../../../assets/images/logo.png';
 import { hexadecimal } from '../../../utils/StringUtils';
-import { Button, Chip, Menu, MenuItem } from '@material-ui/core';
+import { Button, Menu, MenuItem } from '@material-ui/core';
 import { ArrowDropDown, Link, LinkOff } from '@material-ui/icons';
 import ConnectionModal from '../modals/connection/ConnectionModal';
 import { HeaderActionsType, HeaderStateType } from './Header.container';
@@ -47,9 +47,15 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
     return (
       <header className="header">
         <img src={logo} alt="logo" className="logo" />
-        <div className="kbd-select" onClick={this.onClickDevice}>
+        <div
+          className={[
+            'kbd-select',
+            Number.isNaN(this.props.openedDeviceId) ? 'hidden' : '',
+          ].join(' ')}
+          onClick={this.onClickDevice}
+        >
           <div className="kbd-name">
-            <h2>{this.props.keyboardName}</h2>
+            <h2>{this.props.productName}</h2>
             <div className="ids">
               VID: {hexadecimal(this.props.vendorId!, 4)} / PID:{' '}
               {hexadecimal(this.props.productId!, 4)}
@@ -58,13 +64,6 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
           <ArrowDropDown />
         </div>
         <div className="status">
-          <Chip
-            variant="outlined"
-            size="small"
-            label={this.props.connected ? 'Connected' : 'Disconnected'}
-            color={this.props.connected ? 'primary' : 'secondary'}
-            className="connection"
-          />
           <Menu
             anchorEl={this.state.connectionStateEl}
             keepMounted
@@ -74,15 +73,15 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
             {Object.keys(this.props.devices!).map((key) => {
               const id = Number(key);
               const device: Device = this.props.devices![id];
-              const isConnectedDevice = this.props.connectedDeviceId == id;
-              const linking = isConnectedDevice ? 'link-on' : 'link-off';
+              const isOpenedDevice = this.props.openedDeviceId == id;
+              const linking = isOpenedDevice ? 'link-on' : 'link-off';
               return (
                 <MenuItem
                   key={id}
                   onClick={this.props.onClickDeviceMenuItem!.bind(this, id)}
                 >
                   <div className="device-item">
-                    {isConnectedDevice ? (
+                    {isOpenedDevice ? (
                       <Link fontSize="small" className="link-icon link-on" />
                     ) : (
                       <LinkOff
@@ -91,7 +90,7 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
                       />
                     )}
                     <div className={['device-name', linking].join(' ')}>
-                      {device.name}
+                      {device.productName}
                       <span className="device-ids">
                         (VID: {hexadecimal(device.vendorId, 4)} / PID:{' '}
                         {hexadecimal(device.productId, 4)})
@@ -119,7 +118,12 @@ export default class Header extends React.Component<HeaderProps, HeaderState> {
             </MenuItem>
           </Menu>
         </div>
-        <div className="buttons">
+        <div
+          className={[
+            'buttons',
+            Number.isNaN(this.props.openedDeviceId) ? 'hidden' : '',
+          ].join(' ')}
+        >
           <Button
             size="small"
             color="primary"

--- a/src/components/configure/keyboardlist/KeyboardList.container.ts
+++ b/src/components/configure/keyboardlist/KeyboardList.container.ts
@@ -1,0 +1,27 @@
+import { connect } from 'react-redux';
+import KeyboardList from './KeyboardList';
+import { RootState } from '../../../store/state';
+import { Device, KeycodesActions } from '../../../actions/actions';
+import { hidActionsThunk } from '../../../actions/hid.action';
+
+export type KeyboardListStateType = {
+  devices: { [id: number]: Device };
+};
+const mapStateToProps = (state: RootState): KeyboardListStateType => {
+  return {
+    devices: state.hid.devices || [],
+  };
+};
+
+const mapDispatchToProps = (_dispatch: any) => {
+  return {
+    onClickItem: (id: number) => {
+      _dispatch(hidActionsThunk.connectDevice(id));
+      _dispatch(KeycodesActions.updateCategoryIndex(0)); // init keycode categroy
+    },
+  };
+};
+
+export type KeyboardListActionsType = ReturnType<typeof mapDispatchToProps>;
+
+export default connect(mapStateToProps, mapDispatchToProps)(KeyboardList);

--- a/src/components/configure/keyboardlist/KeyboardList.scss
+++ b/src/components/configure/keyboardlist/KeyboardList.scss
@@ -1,0 +1,39 @@
+@import '../../../variables';
+
+.keyboardlist-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding-top: $space-xl;
+  .message {
+    padding: $space-m 0;
+    font-size: 1rem;
+  }
+  .keyboardlist {
+    width: 320px;
+    height: 304px;
+    overflow-y: scroll;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+
+    .keyboard-item {
+      border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+      border-left: 3px solid white;
+      padding: $space-m;
+      cursor: pointer;
+      &:hover {
+        border-left: 3px solid $primary;
+        background-color: $primary-pale;
+      }
+      h3 {
+        font-weight: 700;
+        font-size: 1.2rem;
+        margin: 0;
+      }
+      .device-ids {
+        font-weight: 400;
+        font-size: 40%;
+      }
+    }
+  }
+}

--- a/src/components/configure/keyboardlist/KeyboardList.tsx
+++ b/src/components/configure/keyboardlist/KeyboardList.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Device } from '../../../actions/actions';
+import { hexadecimal } from '../../../utils/StringUtils';
+import {
+  KeyboardListActionsType,
+  KeyboardListStateType,
+} from './KeyboardList.container';
+import './KeyboardList.scss';
+
+type OwnProps = {};
+type KeyboardListProps = OwnProps &
+  Partial<KeyboardListStateType> &
+  Partial<KeyboardListActionsType>;
+
+export default class KeyboardList extends React.Component<
+  KeyboardListProps,
+  {}
+> {
+  constructor(props: KeyboardListProps | Readonly<KeyboardListProps>) {
+    super(props);
+  }
+  render() {
+    return (
+      <div className="keyboardlist-wrapper">
+        <div className="message">Please select a keyboard</div>
+        <div className="keyboardlist">
+          {Object.keys(this.props.devices!).map((key) => {
+            const id = Number(key);
+            const device: Device = this.props.devices![id];
+            return (
+              <div
+                key={id}
+                className="keyboard-item"
+                onClick={this.props.onClickItem!.bind(this, id)}
+              >
+                <h3>{device.productName}</h3>
+                <div className="device-ids">
+                  VID: {hexadecimal(device.vendorId, 4)} / PID:{' '}
+                  {hexadecimal(device.productId, 4)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/components/configure/keymap/Keymap.scss
+++ b/src/components/configure/keymap/Keymap.scss
@@ -1,0 +1,15 @@
+.keydiff-wrapper {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  margin-top: -32px;
+}
+
+.keyboards-wrapper {
+  display: flex;
+  flex-direction: row;
+
+  .balancer {
+    width: 140px;
+  }
+}

--- a/src/components/configure/keymap/Keymap.tsx
+++ b/src/components/configure/keymap/Keymap.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import './Keymap.scss';
+import Keyboards from '../keyboards/Keyboards';
+import Keydiff from '../keydiff/Keydiff';
+
+//import kbdConfig from '../../../assets/files/lunakey-mini.json';
+import kbdConfig from '../../../assets/files/lunakey-mini-test.json';
+import KeyModel from '../../../models/KeyModel';
+//import kbdConfig from '../../../assets/files/iso60.json';
+
+export default class Keymap extends React.Component {
+  private origKey = new KeyModel(
+    'Enter',
+    0,
+    0,
+    1.25,
+    2,
+    '#cccccc',
+    30,
+    2,
+    3,
+    -0.25,
+    0,
+    1.5,
+    1
+  );
+  private destKey = new KeyModel('Caps Lock', 0, 0, 2, 1, '#cccccc', -15, 3, 4);
+  render() {
+    return (
+      <React.Fragment>
+        <div className="keydiff-wrapper">
+          <div className="spacer"></div>
+          <Keydiff origin={this.origKey} destination={this.destKey} />
+          <div className="spacer"></div>
+        </div>
+        <div className="keyboards-wrapper">
+          <div className="spacer"></div>
+          <Keyboards config={kbdConfig} />
+          <div className="balancer"></div>
+          <div className="spacer"></div>
+        </div>
+      </React.Fragment>
+    );
+  }
+}

--- a/src/components/configure/nokeyboard/NoKeyboard.tsx
+++ b/src/components/configure/nokeyboard/NoKeyboard.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default class NoKeyboard extends React.Component {
+  // TODO: SCSS and Web HID access dialog
+  render() {
+    return (
+      <div>
+        no keyboard. Please connect a QMK compatible keyboard and give this app
+        permission for Web HID access
+      </div>
+    );
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,11 +4,15 @@ import './index.scss';
 import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
+import { composeWithDevTools } from 'redux-devtools-extension';
 import App from './App';
 import reducers from './store/reducers';
 import reportWebVitals from './reportWebVitals';
 
-const store = createStore(reducers, applyMiddleware(thunk));
+const store = createStore(
+  reducers,
+  composeWithDevTools(applyMiddleware(thunk))
+);
 
 ReactDOM.render(
   <Provider store={store}>

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -10,7 +10,7 @@ import {
 } from '../actions/actions';
 import {
   HID_ACTIONS,
-  HID_CONNECT_DEVICE,
+  HID_OPEN_DEVICE,
   HID_UPDATE_DEVICE_LIST,
 } from '../actions/hid.action';
 import { MacroKeycodeType } from '../components/configure/keycodes/Keycodes.container';
@@ -33,8 +33,8 @@ const reducers = (state: RootState = INIT_STATE, action: Action) =>
 const hidReducer = (action: Action, draft: RootState) => {
   // TODO: type-safe
   switch (action.type) {
-    case HID_CONNECT_DEVICE: {
-      draft.hid.connectedDeviceId = action.value.id;
+    case HID_OPEN_DEVICE: {
+      draft.hid.openedDeviceId = action.value.id;
       break;
     }
     case HID_UPDATE_DEVICE_LIST: {

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -19,9 +19,10 @@ export type RootState = {
   };
   hid: {
     instance: IHid;
-    devices: { [id: number]: Device };
-    connectedDeviceId: number;
-    connectedKeyboard: IKeyboard | null;
+    devices: { [id: number]: Device }; // DEPRECTAED: use keyboards
+    keyboards: IKeyboard[]; // authorized keyboard list
+    openedDeviceId: number; // DEPRECATED: use openedKeyboard
+    openedKeyboard: IKeyboard | null;
   };
   keycodes: {
     categoryIndex: number;
@@ -62,14 +63,15 @@ export const INIT_STATE: RootState = {
     instance: new WebHid(),
     devices: {
       // TODO: get initial devices
-      0: { name: 'Lunakey Pro', vendorId: 39321, productId: 1 },
-      1: { name: 'Lunakey Mini', vendorId: 22868, productId: 1 },
+      0: { productName: 'Lunakey Pro', vendorId: 39321, productId: 1 },
+      1: { productName: 'Lunakey Mini', vendorId: 22868, productId: 1 },
     },
-    connectedDeviceId: NaN, // id of hid.devices
-    connectedKeyboard: null,
+    keyboards: [],
+    openedDeviceId: NaN, // id of hid.devices
+    openedKeyboard: null, // hid.keyboards[i]
   },
   keycodes: {
-    categoryIndex: 0,
+    categoryIndex: NaN,
   },
   keycodeKey: {
     selectedKey: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -10080,6 +10080,11 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-devtools-extension@^2.13.8:
+  version "2.13.8"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz#37b982688626e5e4993ff87220c9bbb7cd2d96e1"
+  integrity sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg==
+
 redux-thunk@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"


### PR DESCRIPTION
<img width="840" alt="スクリーンショット 2021-01-02 12 18 51" src="https://user-images.githubusercontent.com/316463/103450097-c1145b00-4cf4-11eb-9bbc-d3bcf7afefff.png">

動作テストのため、接続キーボードが1つでもリストを表示するようにしています。
最終的には接続キーボードが1つのときは自動でopenしてキーマップを編集できるようにします（[#54](https://github.com/yoichiro/remap/issues/54)）