### PR TITLE
resolve #176: show hexadecimal label

### DIFF
--- a/src/components/configure/keycodekey/KeycodeKey.container.ts
+++ b/src/components/configure/keycodekey/KeycodeKey.container.ts
@@ -12,6 +12,7 @@ import {
   IKeycodeInfo,
   IKeymap,
 } from '../../../services/hid/Hid';
+import { hexadecimal } from '../../../utils/StringUtils';
 
 export type Key = {
   label: string;
@@ -26,7 +27,7 @@ export const genKey = (keymap: IKeymap): Key => {
     return {
       label: keymap.keycodeInfo
         ? keymap.keycodeInfo.label
-        : `(${Number(keymap.code).toString(16).toUpperCase()})`,
+        : `${hexadecimal(keymap.code)}`,
       meta: '',
       keymap,
     };


### PR DESCRIPTION
<img width="861" alt="スクリーンショット 2021-01-17 6 39 09" src="https://user-images.githubusercontent.com/316463/104823657-1fae0d00-588f-11eb-9156-6aaa0bcbb31e.png">

show "0x" on the keycap label which is not default keycode